### PR TITLE
Fix setting empty IP when cannot fetch. Add log levels. Add custom IP check URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.20 as build
+FROM golang:1.23.1-alpine3.20 AS build
 ARG OS
 ARG ARCH
 COPY . /build/

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Here,
 
 `NC_PASS` is your Dynamic DDNS password which is generated from Namecheap.
 
-You can also use an additional optional env variable:
+You can also use an additional optional env variables:
 
 `CUSTOM_IPCHECK_URL` is an optional variable where you can specify any URL that is used to get the current IP. The program uses HTTP GET method without additional parameters and expects a valid JSON with `ip` field.
+
+`LOG_LEVEL` can be DEBUG, INFO, WARN, ERROR. Default is INFO
 
 * Check the log
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Here,
 
 `NC_PASS` is your Dynamic DDNS password which is generated from Namecheap.
 
+You can also use an additional optional env variable:
+
+`CUSTOM_IPCHECK_URL` is an optional variable where you can specify any URL that is used to get the current IP. The program uses HTTP GET method without additional parameters and expects a valid JSON with `ip` field.
+
 * Check the log
 
 ```
@@ -56,6 +60,49 @@ docker stop server.example.com # To stop
 docker start server.example.com # To start after its stopped
 docker rm server.example.com -f # To remove
 ```
+
+### Alternative Configuration using Docker Compose
+
+If you prefer to configure and manage your Docker containers using Docker Compose, follow the steps outlined below. This approach simplifies the configuration and management by allowing you to define all necessary parameters in a `docker-compose.yml` file.
+
+1. Ensure that Docker and Docker Compose are installed on your server.
+
+2. Create a `docker-compose.yml` file with the following content. Replace the placeholder values with your actual configuration:
+
+    ```yaml
+    services:
+      ddns:
+        image: linuxshots/namecheap-ddns
+        container_name: server.example.com
+        environment:
+          - NC_HOST=server
+          - NC_DOMAIN=example.com
+          - NC_PASS=DynamicDDNSPa2w0rd
+        restart: unless-stopped
+    ```
+
+3. Run the following command in the directory containing your `docker-compose.yml` file to start the container:
+
+    ```sh
+    docker-compose up -d
+    ```
+
+4. Check the logs to ensure the service is running correctly:
+
+    ```sh
+    docker-compose logs ddns
+    ```
+
+5. To manage the container (stop, start, remove), you can use Docker Compose commands:
+
+    ```sh
+    docker-compose stop ddns     # To stop the service
+    docker-compose start ddns    # To start the service again after it’s stopped
+    docker-compose down          # To stop and remove the container
+    ```
+
+By using Docker Compose, you simplify the deployment process and gain better control over your Docker services. This method is particularly useful for managing multiple containers and configurations in a unified manner.
+
 
 ## Build your own image
 

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ "$NC_HOST" == "" -o "$NC_DOMAIN" == "" -o "$NC_PASS" == "" ]; then
-    echo "ERROR NC_HOST, NC_DOMAIN and GD_PASS are mandatory."
+    echo "ERROR NC_HOST, NC_DOMAIN and NC_PASS are mandatory."
     echo "Use --env with docker run to pass these environment variables."
     exit 1
 fi
 
-/app/ncddns --host="$NC_HOST" --domain="$NC_DOMAIN" --password="$NC_PASS"
+/app/ncddns --host="$NC_HOST" --domain="$NC_DOMAIN" --password="$NC_PASS" --custom-ipcheck-url="$CUSTOM_IPCHECK_URL" --log-level="$LOG_LEVEL"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -3,7 +3,7 @@
 if [ $# -ne 1 ]; then
     echo "Exactly one argument required"
     echo "bash docker-build.sh VERSION"
-    echo "  e.g. bash docker-build.sh 1.3.0"
+    echo "  e.g. bash docker-build.sh 1.4.0"
     exit 1
 fi
 

--- a/logger.go
+++ b/logger.go
@@ -8,19 +8,19 @@ import (
 
 // LogLevel constants
 const (
-	DebugLog	   string = "DEBUG"
+	DebugLog       string = "DEBUG"
 	InformationLog string = "INFO"
-	WarningLog	   string = "WARN"
-	ErrorLog	   string = "ERROR"
+	WarningLog     string = "WARN"
+	ErrorLog       string = "ERROR"
 )
 
 var (
-	logLevel			string
-	StdoutInfoLogger	*log.Logger
+	logLevel            string
+	StdoutInfoLogger    *log.Logger
 	StdoutWarningLogger *log.Logger
 	StdoutErrorLogger   *log.Logger
 	StdoutDebugLogger   *log.Logger
-	logLevelPriority	map[string]int
+	logLevelPriority    map[string]int
 )
 
 func init() {
@@ -32,10 +32,10 @@ func init() {
 	
 	// Initialize log level priorities
 	logLevelPriority = map[string]int{
-		DebugLog:		1,
+		DebugLog:       1,
 		InformationLog: 2,
-		WarningLog:		3,
-		ErrorLog:		4,
+		WarningLog:     3,
+		ErrorLog:       4,
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -6,31 +6,54 @@ import (
 	"os"
 )
 
+// LogLevel constants
 const (
-	ErrorLog       string = "ERROR"
+	DebugLog	   string = "DEBUG"
 	InformationLog string = "INFO"
-	WarningLog     string = "WARN"
+	WarningLog	   string = "WARN"
+	ErrorLog	   string = "ERROR"
 )
 
-func DDNSLogger(logType, host, domain, message string) {
+var (
+	logLevel			string
+	StdoutInfoLogger	*log.Logger
+	StdoutWarningLogger *log.Logger
+	StdoutErrorLogger   *log.Logger
+	StdoutDebugLogger   *log.Logger
+	logLevelPriority	map[string]int
+)
 
-	var (
-		StdoutInfoLogger    *log.Logger
-		StdoutWarningLogger *log.Logger
-		StdoutErrorLogger   *log.Logger
-	)
-
+func init() {
+	// Initialize loggers
 	StdoutInfoLogger = log.New(os.Stdout, "INFO ", log.Ldate|log.Ltime)
 	StdoutWarningLogger = log.New(os.Stdout, "WARNING ", log.Ldate|log.Ltime)
 	StdoutErrorLogger = log.New(os.Stdout, "ERROR ", log.Ldate|log.Ltime)
+	StdoutDebugLogger = log.New(os.Stdout, "DEBUG ", log.Ldate|log.Ltime)
+	
+	// Initialize log level priorities
+	logLevelPriority = map[string]int{
+		DebugLog:		1,
+		InformationLog: 2,
+		WarningLog:		3,
+		ErrorLog:		4,
+	}
+}
 
-	if logType == "INFO" {
-		StdoutInfoLogger.Println(host+"."+domain, message)
-	} else if logType == "WARN" {
-		StdoutWarningLogger.Println(host+"."+domain, message)
-	} else if logType == "ERROR" {
-		StdoutErrorLogger.Println(host+"."+domain, message)
-	} else {
-		fmt.Println(host+"."+domain, message)
+func DDNSLogger(logType, host, domain, message string) {
+	// Ensure logType maps to a valid priority
+	if logLevelPriority[logType] >= logLevelPriority[logLevel] {
+		logMessage := fmt.Sprintf("%s.%s %s", host, domain, message)
+		switch logType {
+		case DebugLog:
+			StdoutDebugLogger.Println(logMessage)
+		case InformationLog:
+			StdoutInfoLogger.Println(logMessage)
+		case WarningLog:
+			StdoutWarningLogger.Println(logMessage)
+		case ErrorLog:
+			StdoutErrorLogger.Println(logMessage)
+		default:
+			fmt.Println(logMessage)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,17 +13,39 @@ func main() {
 	domain := flag.String("domain", "", "Domain name e.g. example.com")
 	host := flag.String("host", "", "Subdomain or hostname e.g. www")
 	password := flag.String("password", "", "Dynamic DNS Password from Namecheap")
-	// iPCacheTimeOutSeconds := flag.Int("ip-cache-timeout", 86400, "IP cache timeout in seconds.")
+	custom_ipcheck_url := flag.String("custom-ipcheck-url", "", "Custom IP check URL. Script always falls back to default ones")
+	logLevelFlag := flag.String("log-level", InformationLog, "Log level (DEBUG, INFO, WARN, ERROR) - default is INFO")
 
 	flag.Parse()
+
+	// Set log level based on flag
+	logLevel = *logLevelFlag
+
+	if logLevel == "" {
+		logLevel = InformationLog
+	}
+
+	// Validate log level
+	validLogLevels := map[string]bool{
+		DebugLog:		true,
+		InformationLog: true,
+		WarningLog:		true,
+		ErrorLog:		true,
+	}
+
+	if !validLogLevels[logLevel] {
+		fmt.Println("ERROR: Invalid log level. Supported values are DEBUG, INFO, WARN, ERROR")
+		os.Exit(1)
+	}
+
 	if *domain == "" || *host == "" || *password == "" {
-		fmt.Println("ERROR domain, host and Dynamic DDNS password are mandatory")
+		fmt.Println("ERROR: domain, host and Dynamic DDNS password are mandatory")
 		fmt.Printf("\nUsage of %s:\n", os.Args[1])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	pubIp, err := getPubIP()
+	pubIp, err := getPubIP(*custom_ipcheck_url)
 	if err != nil {
 		DDNSLogger(ErrorLog, *host, *domain, err.Error())
 	} else {
@@ -35,5 +57,5 @@ func main() {
 		}
 	}
 
-	updateRecord(*domain, *host, *password)
+	updateRecord(*domain, *host, *password, *custom_ipcheck_url)
 }

--- a/main.go
+++ b/main.go
@@ -27,10 +27,10 @@ func main() {
 
 	// Validate log level
 	validLogLevels := map[string]bool{
-		DebugLog:		true,
+		DebugLog:       true,
 		InformationLog: true,
-		WarningLog:		true,
-		ErrorLog:		true,
+		WarningLog:     true,
+		ErrorLog:       true,
 	}
 
 	if !validLogLevels[logLevel] {

--- a/model.go
+++ b/model.go
@@ -15,7 +15,7 @@ func (err *CustomError) Error() string {
 }
 
 var (
-	version          string        = "1.3.0-go1.23"
+	version          string        = "1.4.0-go1.23"
 	daemon_poll_time time.Duration = 1 * time.Minute // Time in minute
 	gitrepo          string        = "https://github.com/navilg/namecheap-ddns-docker"
 	httpTimeout      time.Duration = 30 * time.Second


### PR DESCRIPTION
Fixes #16 

And many other improvements:

Log levels - I added DEBUG log level, and introduced log_level variable which limits output to logs
Custom IP Check URL - if supplied, the URL will be fetched before the default 2 endpoints. Response just must have JSON reply with 'ip' field

minor fixes